### PR TITLE
Relocatable executable

### DIFF
--- a/.local/aarch64-test-runners.sh
+++ b/.local/aarch64-test-runners.sh
@@ -2,11 +2,10 @@
 set -e
 cd test-runners
 cd small-main
-RUSTFLAGS='-C panic=abort -C link-arg=-nostartfiles -C target-feature=+crt-static -C relocation-model=static' cross b -r --target aarch64-unknown-linux-gnu
+RUSTFLAGS='-C panic=abort -C link-arg=-nostartfiles -C target-feature=+crt-static -C relocation-model=pie' cross b -r --target aarch64-unknown-linux-gnu
 qemu-aarch64 target/aarch64-unknown-linux-gnu/release/small-main dummy_arg
-
 cd ..
 cd alloc-main
-RUSTFLAGS='-C panic=abort -C link-arg=-nostartfiles -C target-feature=+crt-static -C relocation-model=static' cross b -r --target aarch64-unknown-linux-gnu
+RUSTFLAGS='-C panic=abort -C link-arg=-nostartfiles -C target-feature=+crt-static -C relocation-model=pie' cross b -r --target aarch64-unknown-linux-gnu
 qemu-aarch64 target/aarch64-unknown-linux-gnu/release/alloc-main dummy_arg
 echo "Aarch64 Test runners completed successfully"

--- a/.local/x86_64-test-runners.sh
+++ b/.local/x86_64-test-runners.sh
@@ -2,9 +2,24 @@
 set -e
 cd test-runners
 cd small-main
-RUSTFLAGS='-C panic=abort -C link-arg=-nostartfiles -C link-arg=-fuse-ld=mold -C target-feature=+crt-static -C relocation-model=static' cargo r --target x86_64-unknown-linux-gnu -- dummy_arg
+RUSTFLAGS='-C panic=abort -C link-arg=-nostartfiles -C link-arg=-fuse-ld=mold -C target-feature=+crt-static -C relocation-model=pie -g' cargo r -r --target x86_64-unknown-linux-gnu -- dummy_arg
+echo "Built and ran small main release static pie"
+RUSTFLAGS='-C panic=abort -C link-arg=-nostartfiles -C link-arg=-fuse-ld=mold -g' cargo r --target x86_64-unknown-linux-gnu -- dummy_arg
+echo "Built and ran small main debug"
+RUSTFLAGS='-C panic=abort -C link-arg=-nostartfiles -C link-arg=-fuse-ld=mold -g' cargo r -r --target x86_64-unknown-linux-gnu -- dummy_arg
+echo "Built and ran small main release"
+RUSTFLAGS='-C panic=abort -C link-arg=-nostartfiles -C link-arg=-fuse-ld=mold -C target-feature=+crt-static -C relocation-model=static -g' cargo r -r --target x86_64-unknown-linux-gnu -- dummy_arg
+echo "Built and ran small main release static absolute"
+
 
 cd ..
 cd alloc-main
+RUSTFLAGS='-C panic=abort -C link-arg=-nostartfiles -C link-arg=-fuse-ld=mold -g' cargo r --target x86_64-unknown-linux-gnu -- dummy_arg
+echo "Built and ran alloc main debug"
+RUSTFLAGS='-C panic=abort -C link-arg=-nostartfiles -C link-arg=-fuse-ld=mold -g' cargo r -r --target x86_64-unknown-linux-gnu -- dummy_arg
+echo "Built and ran alloc main release"
 RUSTFLAGS='-C panic=abort -C link-arg=-nostartfiles -C link-arg=-fuse-ld=mold -C target-feature=+crt-static -C relocation-model=static -g' cargo r -r --target x86_64-unknown-linux-gnu -- dummy_arg
+echo "Built and ran alloc main release static absolute"
+RUSTFLAGS='-C panic=abort -C link-arg=-nostartfiles -C link-arg=-fuse-ld=mold -C target-feature=+crt-static -C relocation-model=pie -g' cargo r -r --target x86_64-unknown-linux-gnu -- dummy_arg
+echo "Built and ran alloc main release static pie"
 echo "x86_64 Test runners completed successfully"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "linux-rust-bindings"
 version = "0.1.0"
-source = "git+https://github.com/MarcusGrass/linux-rust-bindings?rev=d8c402a9b2a5ed3e33e85a21009e32a5b997ba60#d8c402a9b2a5ed3e33e85a21009e32a5b997ba60"
+source = "git+https://github.com/MarcusGrass/linux-rust-bindings?rev=3b64f3e389717632d9100a0300e9224e9a1d2fdc#3b64f3e389717632d9100a0300e9224e9a1d2fdc"
 
 [[package]]
 name = "rusl"

--- a/rusl/Cargo.toml
+++ b/rusl/Cargo.toml
@@ -10,6 +10,6 @@ default = ["alloc"]
 alloc = []
 
 [dependencies]
-linux-rust-bindings = { git = "https://github.com/MarcusGrass/linux-rust-bindings", rev = "d8c402a9b2a5ed3e33e85a21009e32a5b997ba60", default-features = false, features = ["all"] }
+linux-rust-bindings = { git = "https://github.com/MarcusGrass/linux-rust-bindings", rev = "3b64f3e389717632d9100a0300e9224e9a1d2fdc", features = ["all"] }
 sc = "0.2.7"
 unix-print = "0.1.0"

--- a/rusl/src/macros.rs
+++ b/rusl/src/macros.rs
@@ -33,23 +33,23 @@ macro_rules! transparent_bitflags {
                 $vis const $Flag: Self = Self($value);
             )*
 
-            #[inline]
-            #[allow(dead_code)]
             #[must_use]
+            #[inline(always)]
+            #[allow(dead_code)]
             $vis const fn bits(&self) -> $T {
                 self.0
             }
 
             #[inline]
-            #[allow(dead_code)]
             #[must_use]
+            #[allow(dead_code)]
             $vis const fn empty() -> Self {
                 Self::DEFAULT
             }
 
             #[inline]
-            #[allow(dead_code)]
             #[must_use]
+            #[allow(dead_code)]
             $vis fn contains(&self, other: Self) -> bool {
                 self.0 & other.0 != Self::DEFAULT.0
             }

--- a/rusl/src/platform/compat.rs
+++ b/rusl/src/platform/compat.rs
@@ -2,6 +2,7 @@ pub use crate::platform::numbers::NonNegativeI32;
 pub use auxvec::*;
 pub use clone::*;
 pub use dirent::*;
+pub use elf::*;
 pub use epoll::*;
 pub use fcntl::*;
 pub use futex::*;
@@ -19,12 +20,12 @@ pub use time::*;
 pub use uio::*;
 pub use usb::*;
 pub use utsname::*;
-pub use vdso::*;
 pub use wait::*;
 
 mod auxvec;
 mod clone;
 mod dirent;
+mod elf;
 mod epoll;
 mod fcntl;
 mod futex;
@@ -42,7 +43,6 @@ mod time;
 mod uio;
 mod usb;
 mod utsname;
-mod vdso;
 mod wait;
 
 /// Shared typedefs for 64 bit systems (GNU source)

--- a/rusl/src/platform/compat/auxvec.rs
+++ b/rusl/src/platform/compat/auxvec.rs
@@ -1,6 +1,8 @@
 // Got this from `musl` gotta see if I can find it in the kernel source
 pub const AUX_CNT: usize = 42;
 
+pub use linux_rust_bindings::aux::*;
+
 transparent_bitflags! {
     pub struct AuxValue: usize {
         const DEFAULT = 0;

--- a/rusl/src/platform/compat/elf.rs
+++ b/rusl/src/platform/compat/elf.rs
@@ -1,5 +1,12 @@
 use core::mem::MaybeUninit;
 
+pub use linux_rust_bindings::elf::*;
+
+#[cfg(target_arch = "x86_64")]
+pub const REL_RELATIVE: u64 = 8;
+#[cfg(target_arch = "aarch64")]
+pub const REL_RELATIVE: u64 = 1027;
+
 #[repr(transparent)]
 #[derive(Debug, Copy, Clone)]
 #[cfg(target_pointer_width = "32")]
@@ -69,3 +76,18 @@ pub struct ElfSymbol(pub linux_rust_bindings::elf::Elf32_Sym);
 #[repr(transparent)]
 #[cfg(target_pointer_width = "64")]
 pub struct ElfSymbol(pub linux_rust_bindings::elf::Elf64_Sym);
+
+#[derive(Debug, Copy, Clone)]
+#[repr(transparent)]
+#[cfg(target_pointer_width = "64")]
+pub struct ElfPhdr(pub linux_rust_bindings::elf::Elf64_Phdr);
+
+#[derive(Debug, Copy, Clone)]
+#[repr(transparent)]
+#[cfg(target_pointer_width = "64")]
+pub struct Elf64Rel(pub linux_rust_bindings::elf::Elf64_Rel);
+
+#[derive(Debug, Copy, Clone)]
+#[repr(transparent)]
+#[cfg(target_pointer_width = "64")]
+pub struct Elf64Rela(pub linux_rust_bindings::elf::Elf64_Rela);

--- a/rusl/src/platform/compat/io_uring.rs
+++ b/rusl/src/platform/compat/io_uring.rs
@@ -717,7 +717,7 @@ impl IoUringParams {
                 dropped: 0,
                 array: 0,
                 resv1: 0,
-                resv2: 0,
+                user_addr: 0,
             },
             cq_off: io_cqring_offsets {
                 head: 0,
@@ -728,7 +728,7 @@ impl IoUringParams {
                 cqes: 0,
                 flags: 0,
                 resv1: 0,
-                resv2: 0,
+                user_addr: 0,
             },
         })
     }

--- a/rusl/src/platform/numbers/non_negative_i32.rs
+++ b/rusl/src/platform/numbers/non_negative_i32.rs
@@ -13,6 +13,12 @@ impl core::fmt::Display for NonNegativeI32 {
     }
 }
 
+impl Default for NonNegativeI32 {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
 impl NonNegativeI32 {
     pub const ZERO: Self = Self(0);
 
@@ -34,8 +40,15 @@ impl NonNegativeI32 {
         }
     }
 
+    /// Const constructor which panics on error, useful for constructing constants, as
+    /// the compilation will make sure this is correct and safe.
+    /// If used outside of a const context however, this will just panic on failure, which
+    /// sucks, if not in const, then run `try_new`.
+    /// # Panics
+    /// Only when constructing a negative i32, don't use this function outside of a const context.
     #[inline]
-    pub(crate) const fn comptime_checked_new(val: i32) -> Self {
+    #[must_use]
+    pub const fn comptime_checked_new(val: i32) -> Self {
         assert!(
             val >= 0,
             "Tried to comptime create a NonNegativeI32 from a value less than zero"

--- a/test-runners/alloc-main/Cargo.lock
+++ b/test-runners/alloc-main/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 [[package]]
 name = "linux-rust-bindings"
 version = "0.1.0"
-source = "git+https://github.com/MarcusGrass/linux-rust-bindings?rev=d8c402a9b2a5ed3e33e85a21009e32a5b997ba60#d8c402a9b2a5ed3e33e85a21009e32a5b997ba60"
+source = "git+https://github.com/MarcusGrass/linux-rust-bindings?rev=3b64f3e389717632d9100a0300e9224e9a1d2fdc#3b64f3e389717632d9100a0300e9224e9a1d2fdc"
 
 [[package]]
 name = "rusl"

--- a/test-runners/small-main/Cargo.lock
+++ b/test-runners/small-main/Cargo.lock
@@ -5,7 +5,7 @@ version = 3
 [[package]]
 name = "linux-rust-bindings"
 version = "0.1.0"
-source = "git+https://github.com/MarcusGrass/linux-rust-bindings?rev=d8c402a9b2a5ed3e33e85a21009e32a5b997ba60#d8c402a9b2a5ed3e33e85a21009e32a5b997ba60"
+source = "git+https://github.com/MarcusGrass/linux-rust-bindings?rev=3b64f3e389717632d9100a0300e9224e9a1d2fdc#3b64f3e389717632d9100a0300e9224e9a1d2fdc"
 
 [[package]]
 name = "rusl"

--- a/test-runners/small-main/src/main.rs
+++ b/test-runners/small-main/src/main.rs
@@ -2,7 +2,6 @@
 #![no_main]
 #![allow(dead_code)]
 
-use rusl::platform::AuxValue;
 use tiny_std::io::Read;
 use tiny_std::process::{Environment, Stdio};
 
@@ -86,18 +85,13 @@ fn test_spawn_with_args() {
 }
 
 unsafe fn test_aux_values() {
-    let page_size = tiny_std::start::get_aux_value(AuxValue::AT_PAGESZ).unwrap();
-    assert_eq!(4096, page_size);
     // 16 random bytes
-    let random = tiny_std::start::get_aux_value(AuxValue::AT_RANDOM).unwrap() as *const u128;
-    let _val = random.read();
-    let uid = tiny_std::start::get_aux_value(AuxValue::AT_UID).unwrap();
-    let gid = tiny_std::start::get_aux_value(AuxValue::AT_GID).unwrap();
+    let random = tiny_std::elf::aux::get_random();
+    assert_ne!(0u128, random.unwrap());
+    let uid = tiny_std::elf::aux::get_uid();
+    let gid = tiny_std::elf::aux::get_gid();
     assert_eq!(1000, uid);
     assert_eq!(1000, gid);
-    // TODO: Fix VDSO for aarch64
-    #[cfg(not(target_arch = "aarch64"))]
-    let _vdso = tiny_std::start::get_aux_value(AuxValue::AT_SYSINFO_EHDR).unwrap();
 }
 
 fn test_time() {

--- a/tiny-std/Cargo.toml
+++ b/tiny-std/Cargo.toml
@@ -11,7 +11,7 @@ default = ["alloc"]
 # With an allocator, needs to be provided,
 alloc = ["rusl/alloc"]
 # Lib sections of things dependant of start files
-start = []
+start = ["symbols"]
 # Symbols required for properly using start parts, becomes incompatible with stdlib if activated
 symbols = []
 # Pull in aux values in the program entrypoint

--- a/tiny-std/src/elf.rs
+++ b/tiny-std/src/elf.rs
@@ -1,0 +1,8 @@
+#[cfg(feature = "aux")]
+pub mod aux;
+
+#[cfg(feature = "start")]
+pub(crate) mod dynlink;
+
+#[cfg(feature = "vdso")]
+pub(crate) mod vdso;

--- a/tiny-std/src/elf/aux.rs
+++ b/tiny-std/src/elf/aux.rs
@@ -1,0 +1,106 @@
+use rusl::platform::{GidT, UidT};
+
+/// A vector of dynamic values supplied by the OS
+pub(crate) static mut AUX_VALUES: AuxValues = AuxValues::zeroed();
+
+#[inline]
+pub fn get_gid() -> GidT {
+    unsafe { AUX_VALUES.at_gid as GidT }
+}
+
+#[inline]
+pub fn get_uid() -> UidT {
+    unsafe { AUX_VALUES.at_uid as UidT }
+}
+
+#[inline]
+pub fn get_random() -> Option<u128> {
+    unsafe {
+        let random_addr = AUX_VALUES.at_random;
+        if random_addr != 0 {
+            return Some(*(random_addr as *const u128));
+        }
+        None
+    }
+}
+
+/// Some selected aux-values, needs to be kept small since they're collected
+/// before symbol relocation on static-pie-linked binaries, which means rustc
+/// will emit `memset` on a zeroed allocation of over 256 bytes, which we won't be able
+/// to find and thus will result in an immediate segfault on start.
+/// See [docs](https://man7.org/linux/man-pages/man3/getauxval.3.html)
+#[derive(Debug)]
+pub(crate) struct AuxValues {
+    /// Base address of the program interpreter
+    pub(crate) at_base: usize,
+
+    /// Real group id of the main thread
+    pub(crate) at_gid: usize,
+
+    /// Real user id of the main thread
+    pub(crate) at_uid: usize,
+
+    /// Address of the executable's program headers
+    pub(crate) at_phdr: usize,
+
+    /// Size of program header entry
+    pub(crate) at_phent: usize,
+
+    /// Number of program headers
+    pub(crate) at_phnum: usize,
+
+    /// Address pointing to 16 bytes of a random value
+    pub(crate) at_random: usize,
+
+    /// Executable should be treated securely
+    pub(crate) at_secure: usize,
+
+    /// Address of the vdso
+    pub(crate) at_sysinfo_ehdr: usize,
+}
+
+impl AuxValues {
+    #[inline(always)]
+    pub(crate) const fn zeroed() -> Self {
+        Self {
+            at_base: 0,
+            at_gid: 0,
+            at_uid: 0,
+            at_phdr: 0,
+            at_phent: 0,
+            at_phnum: 0,
+            at_random: 0,
+            at_secure: 0,
+            at_sysinfo_ehdr: 0,
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn from_auxv(auxv: *const usize) -> Self {
+        let mut collected = Self::zeroed();
+        let mut i = 0;
+        let mut key = *auxv;
+        while key != 0 {
+            if key <= 51 {
+                match key as i32 {
+                    rusl::platform::AT_PHDR => collected.at_phdr = *(auxv.add(i + 1)),
+                    rusl::platform::AT_PHENT => collected.at_phent = *(auxv.add(i + 1)),
+                    rusl::platform::AT_PHNUM => collected.at_phnum = *(auxv.add(i + 1)),
+                    rusl::platform::AT_BASE => collected.at_base = *(auxv.add(i + 1)),
+                    rusl::platform::AT_UID => collected.at_uid = *(auxv.add(i + 1)),
+                    rusl::platform::AT_GID => collected.at_gid = *(auxv.add(i + 1)),
+                    rusl::platform::AT_SECURE => collected.at_secure = *(auxv.add(i + 1)),
+                    rusl::platform::AT_RANDOM => collected.at_random = *(auxv.add(i + 1)),
+                    rusl::platform::AT_SYSINFO_EHDR => {
+                        collected.at_sysinfo_ehdr = *(auxv.add(i + 1))
+                    }
+                    _ => {}
+                }
+            }
+
+            i += 2;
+            key = *(auxv.add(i));
+        }
+        collected
+    }
+}

--- a/tiny-std/src/elf/dynlink.rs
+++ b/tiny-std/src/elf/dynlink.rs
@@ -1,0 +1,118 @@
+use crate::elf::aux::AuxValues;
+use core::hint::unreachable_unchecked;
+use rusl::platform::{
+    Elf64Rel, Elf64Rela, ElfPhdr, DT_REL, DT_RELA, DT_RELASZ, DT_RELSZ, PT_DYNAMIC, REL_RELATIVE,
+};
+
+#[inline(always)]
+pub(crate) unsafe fn relocate_symbols(dynv: *const usize, aux: &AuxValues) {
+    if dynv as usize != 0 {
+        // Static-pie linked (or dynamic but who would do that?)
+        // We don't have access to any symbols here, at all.
+        let mut base = aux.at_base;
+        if base == 0 {
+            // Got a direct invocation, ie not external linker, that means we're a static pie
+            // and needs to do a relocation
+            let ph_num = aux.at_phnum;
+            let phent = aux.at_phent;
+            let mut phdr_base = aux.at_phdr;
+            // Find dynamic entry to adjust the base relocation addr offset
+            if ph_num > 0 {
+                let mut i = ph_num - 1;
+                while i > 0 {
+                    let phdr = ptr_unsafe_ref((phdr_base + phent) as *const ElfPhdr);
+                    phdr_base += phent;
+                    if phdr.0.p_type == PT_DYNAMIC as u32 {
+                        base = dynv as usize - phdr.0.p_vaddr as usize;
+                        break;
+                    }
+                    if i == 0 {
+                        break;
+                    }
+                    i -= 1;
+                }
+            }
+            let ds = DynSection::init_from_dynv(dynv);
+            ds.relocate(base);
+        }
+    }
+}
+
+pub(crate) struct DynSection {
+    rel: usize,
+    rel_sz: usize,
+    rela: usize,
+    rela_sz: usize,
+}
+
+impl DynSection {
+    /// Function works just like getting aux-values, value is at key + 1
+    #[inline(always)]
+    pub(crate) unsafe fn init_from_dynv(dynv: *const usize) -> Self {
+        let mut ds = Self {
+            rel: 0,
+            rel_sz: 0,
+            rela: 0,
+            rela_sz: 0,
+        };
+        let mut i = 0;
+        let mut key = *dynv;
+        while key != 0 {
+            if key < 19 {
+                let ikey = key as i32;
+                match ikey {
+                    DT_RELA => ds.rela = *(dynv.add(i + 1)),
+                    DT_RELASZ => ds.rela_sz = *(dynv.add(i + 1)),
+                    DT_REL => ds.rel = *(dynv.add(i + 1)),
+                    DT_RELSZ => ds.rel_sz = *(dynv.add(i + 1)),
+                    _ => {}
+                }
+            }
+
+            i += 2;
+            key = *(dynv.add(i));
+        }
+        ds
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn relocate(&self, base_addr: usize) {
+        // Relocate all `rel`-entries
+        for i in 0..(self.rel_sz / core::mem::size_of::<Elf64Rel>()) {
+            let rel_ptr = ((base_addr + self.rel) as *const Elf64Rel).add(i);
+            let rel = ptr_unsafe_ref(rel_ptr);
+            if rel.0.r_info == relative_type(REL_RELATIVE) {
+                let rel_addr = (base_addr + rel.0.r_offset as usize) as *mut usize;
+                *rel_addr += base_addr;
+            }
+        }
+        // Relocate all `rela`-entries
+        for i in 0..(self.rela_sz / core::mem::size_of::<Elf64Rela>()) {
+            let rela_ptr = ((base_addr + self.rela) as *const Elf64Rela).add(i);
+            let rela = ptr_unsafe_ref(rela_ptr);
+            if rela.0.r_info == relative_type(REL_RELATIVE) {
+                let rel_addr = (base_addr + rela.0.r_offset as usize) as *mut usize;
+                *rel_addr = base_addr + rela.0.r_addend as usize;
+            }
+        }
+        // Skip implementing `relr`-entries for now
+    }
+}
+
+#[inline(always)]
+const fn relative_type(tp: u64) -> u64 {
+    tp & 0x7fffffff
+}
+
+#[inline(always)]
+unsafe fn ptr_unsafe_ref<T>(ptr: *const T) -> &'static T {
+    unwrap_unchecked(ptr.as_ref())
+}
+
+#[inline(always)]
+unsafe fn unwrap_unchecked<T>(opt: Option<T>) -> T {
+    match opt {
+        None => unreachable_unchecked(),
+        Some(val) => val,
+    }
+}

--- a/tiny-std/src/lib.rs
+++ b/tiny-std/src/lib.rs
@@ -10,6 +10,8 @@ extern crate alloc;
 
 pub use rusl::string::unix_str::*;
 
+pub mod elf;
+#[cfg(feature = "start")]
 pub mod env;
 pub mod error;
 pub mod fs;
@@ -23,5 +25,3 @@ pub mod start;
 pub mod thread;
 pub mod time;
 pub mod unix;
-#[cfg(feature = "vdso")]
-mod vdso;

--- a/tiny-std/src/process.rs
+++ b/tiny-std/src/process.rs
@@ -202,7 +202,7 @@ impl Command {
         const NULL_ENV: [*const u8; 1] = [core::ptr::null()];
         let envp = match &self.env {
             #[cfg(feature = "start")]
-            Environment::Inherit => unsafe { crate::start::ENV.env_p },
+            Environment::Inherit => unsafe { crate::env::ENV.env_p },
             Environment::None => NULL_ENV.as_ptr(),
             Environment::Provided(provided) => provided.envp.0.as_ptr(),
         };
@@ -229,7 +229,7 @@ impl Command {
         const NULL_ENV: [*const u8; 1] = [core::ptr::null()];
         let envp = match &self.env {
             #[cfg(feature = "start")]
-            Environment::Inherit => unsafe { crate::start::ENV.env_p },
+            Environment::Inherit => unsafe { crate::env::ENV.env_p },
             Environment::None => NULL_ENV.as_ptr(),
             Environment::Provided(provided) => provided.envp.0.as_ptr(),
         };
@@ -579,7 +579,7 @@ pub fn spawn<const N: usize, BIN: AsUnixStr, ARG: AsUnixStr, CL: PreExec>(
     let mut no_args: [*const u8; 2] = [core::ptr::null_mut(), core::ptr::null_mut()];
     let envp = match env {
         #[cfg(feature = "start")]
-        Environment::Inherit => unsafe { crate::start::ENV.env_p },
+        Environment::Inherit => unsafe { crate::env::ENV.env_p },
         Environment::None => NO_ENV.as_ptr(),
     };
     let mut new_args = [core::ptr::null(); N];

--- a/tiny-std/src/thread.rs
+++ b/tiny-std/src/thread.rs
@@ -1,12 +1,12 @@
 /// We'll need symbols to set up a panic_handler, and alloc to run threads.
 /// We also need to set tls, which is done in `start`
-#[cfg(all(not(test), feature = "symbols", feature = "alloc", feature = "start"))]
+#[cfg(all(not(test), feature = "start", feature = "alloc"))]
 pub(crate) mod spawn;
 
 use crate::error::Result;
 use core::time::Duration;
 use rusl::error::Errno;
-#[cfg(all(not(test), feature = "symbols", feature = "alloc", feature = "start"))]
+#[cfg(all(not(test), feature = "start", feature = "alloc"))]
 pub use spawn::*;
 
 /// Sleep the current thread for the provided `Duration`

--- a/tiny-std/src/time.rs
+++ b/tiny-std/src/time.rs
@@ -214,7 +214,7 @@ fn sub_ts_checked_dur(lhs: TimeSpec, rhs: TimeSpec) -> Option<Duration> {
 #[inline]
 #[cfg(feature = "vdso")]
 fn get_monotonic_time() -> TimeSpec {
-    if let Some(vdso_get_time) = unsafe { crate::start::VDSO_CLOCK_GET_TIME } {
+    if let Some(vdso_get_time) = unsafe { crate::elf::vdso::VDSO_CLOCK_GET_TIME } {
         let mut ts = core::mem::MaybeUninit::<TimeSpec>::zeroed();
         vdso_get_time(
             rusl::platform::ClockId::CLOCK_MONOTONIC.bits(),
@@ -230,7 +230,7 @@ fn get_monotonic_time() -> TimeSpec {
 #[inline]
 #[cfg(feature = "vdso")]
 fn get_real_time() -> TimeSpec {
-    if let Some(vdso_get_time) = unsafe { crate::start::VDSO_CLOCK_GET_TIME } {
+    if let Some(vdso_get_time) = unsafe { crate::elf::vdso::VDSO_CLOCK_GET_TIME } {
         let mut ts = core::mem::MaybeUninit::<TimeSpec>::zeroed();
         vdso_get_time(
             rusl::platform::ClockId::CLOCK_REALTIME.bits(),

--- a/tiny-std/src/unix.rs
+++ b/tiny-std/src/unix.rs
@@ -1,4 +1,5 @@
 pub mod fd;
+pub mod host_name;
 pub mod misc;
 pub mod passwd;
 pub mod random;

--- a/tiny-std/src/unix/host_name.rs
+++ b/tiny-std/src/unix/host_name.rs
@@ -1,0 +1,10 @@
+/// Attempts to get the system hostname as a utf8 `String`
+/// # Errors
+/// Hostname is not utf8
+#[cfg(feature = "alloc")]
+pub fn host_name() -> Result<alloc::string::String, crate::error::Error> {
+    #[allow(unused_imports)]
+    use alloc::string::ToString;
+    let raw = rusl::unistd::uname()?;
+    Ok(raw.nodename()?.to_string())
+}

--- a/tiny-std/src/unix/symbols.rs
+++ b/tiny-std/src/unix/symbols.rs
@@ -358,5 +358,12 @@ pub extern "C" fn _Unwind_Resume() -> ! {
 #[no_mangle]
 #[cfg(target_arch = "aarch64")]
 pub extern "C" fn getauxval(_val: u64) -> u64 {
-    panic!("This is a bug, the extern `C` function `getauxval` was invoked, we don't use the `C` implementation here, but code using it was generated. implementation here, but code using it was generated.")
+    panic!("This is a bug, the extern `C` function `getauxval` was invoked, we don't use the `C` implementation here, but code using it was generated.")
 }
+
+/// Skip lang item feature which will never stabilize and just put the symbol in
+/// # Safety
+/// Just a symbol that's necessary
+#[no_mangle]
+#[cfg(feature = "symbols")]
+pub unsafe fn rust_eh_personality() {}


### PR DESCRIPTION
Cleans up a bunch of the `start`-functionality, and makes `tiny-std` possible to relocate itself, ie compile as `static-pie`