### PR TITLE
[Tiny cli] Handle different struct visibilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ checksum = "010e18bd3bfd1d45a7e666b236c78720df0d9a7698ebaa9c1c559961eb60a38b"
 
 [[package]]
 name = "tiny-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "tiny-std",
 ]

--- a/tiny-cli/Cargo.toml
+++ b/tiny-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiny-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MPL-2.0"
 readme = "../Readme.md"

--- a/tiny-cli/Changelog.md
+++ b/tiny-cli/Changelog.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+## [v0.3.1] - 2024-08-26
+
+### Fixed
+- Correctly handles different visibilities on Arg structs
+
 ## [v0.3.0] - 2024-08-24
 
 ### Fixed

--- a/tiny-cli/src/lib.rs
+++ b/tiny-cli/src/lib.rs
@@ -29,7 +29,7 @@ fn pop_expect_punct<I: Iterator<Item = TokenTree>, D: Display>(
         assert_eq!(p.as_char(), expect, "{err_msg}");
     } else {
         panic!(
-            "[ArgParse derive] Expected punctation with {expect}, found: {punct:?}, ctx: {err_msg}"
+            "[ArgParse derive] Expected punctuation with {expect}, found: {punct:?}, ctx: {err_msg}"
         );
     }
 }
@@ -54,7 +54,7 @@ fn pop_ident<I: Iterator<Item = TokenTree>, D: Display>(stream: &mut I, err_msg:
     if let TokenTree::Ident(ident) = ident {
         ident
     } else {
-        panic!("[ArgParse derive] Expected ident, found {ident:?}, ctx: {err_msg}");
+        panic!("[ArgParse derive] Expected ident, found '{ident:?}', ctx: {err_msg}");
     }
 }
 

--- a/tiny-cli/tests/derive_test.rs
+++ b/tiny-cli/tests/derive_test.rs
@@ -167,8 +167,8 @@ Required argument 'pos_two' not supplied.",
 #[derive(ArgParse)]
 #[cli(help_path = "tiny-cli")]
 pub struct MultiArgOptLast {
-    pos_one: String,
-    pos_two: i64,
+    pub pos_one: String,
+    pub(crate) pos_two: i64,
     pos_three: Option<usize>,
 }
 


### PR DESCRIPTION
Fix bug where only private fields were getting correct codegen, adds a test for it